### PR TITLE
docs: corrige histórico de versão adicionando os autores responsáveis

### DIFF
--- a/docs/Base/1.2.4.DiagramaDeCausaeEfeito.md
+++ b/docs/Base/1.2.4.DiagramaDeCausaeEfeito.md
@@ -43,4 +43,4 @@ Para compreender melhor as origens desse problema, as causas foram organizadas e
 
 | Versão | Data | Descrição | Autor | Revisor | Data da Revisão |
 |--------|------|-----------|--------|---------|-----------------|
-| 1.0 | 05/09/2025 | Adição do Diagrama de Causa e Efeito | [Henrique Carvalho](https://github.com/henriquecarv3) | [Kaio Macedo](https://github.com/bigkaio) | 05/09/2025 |
+| 1.0 | 05/09/2025 | Adição do Diagrama de Causa e Efeito | [Henrique Carvalho](https://github.com/henriquecarv3) e [Kaio Macedo](https://github.com/bigkaio)|[Lucas Mendonça](https://github.com/lucasarruda9)  | 05/09/2025 |

--- a/docs/Base/1.3.ModelagemBPMN.md
+++ b/docs/Base/1.3.ModelagemBPMN.md
@@ -95,4 +95,4 @@ O fluxo demonstra um sistema integrado que incentiva práticas sustentáveis atr
 | 1.2 | 04/09/2025 | Adição do BPMN do Uso do Sistema | [Gabriel Lopes](https://github.com/BrzGab) | [Lucas Mendonça](https://github.com/lucasarruda9) | 04/09/2025 |
 | 1.3 | 04/09/2025 | Adição do BPMN do Elicitação de Requisitos | [Gustavo Gontijo](https://github.com/Guga301104) | [Davi Oliveira](https://github.com/daviRolvr), [Ana Luiza Komatsu](https://github.com/luluaroeira) | 04/09/2025 |
 | 1.4 | 04/09/2025 | Adição do BPMN da metodologia Scrum Versão 2 | [Lucas Mendonça](https://github.com/lucasarruda9) | [Artur Mendonça](https://github.com/ArtyMend07) | 04/09/2025 |
-| 1.5 | 04/09/2025 | Adição do BPMN da Sprint Design Versão 1 | [Kaio Macedo](https://github.com/bigkaio) | [Henrique Carvalho](https://github.com/henriquecarv3) | 04/09/2025 |
+| 1.5 | 04/09/2025 | Adição do BPMN da Sprint Design Versão 1 | [Henrique Carvalho](https://github.com/henriquecarv3) e [Kaio Macedo](https://github.com/bigkaio)|[Lucas Mendonça](https://github.com/lucasarruda9)  | 04/09/2025 |


### PR DESCRIPTION
## Descrição

Corrigimos no histórico de versão a autoria dos temas em que abordamos no projeto. Reforçamos que, nossa dupla achou que era para colocar ambos como autor e revisor para assim explicitar que fomos nós dois que trabalhamos na confecção dessas partes no projeto. Porém, agora corrigimos nosso erro.

## Tipo de mudança

- [x] Documentação

## Checklist

- [x] Corrigimos a autoria nos históricos de versão em questão no commit